### PR TITLE
Add class attribute, interpolated values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There may be different usage scenarios for different people. One of them is desc
 
 Usually [`data:URI`](https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs) scheme is used to embed icons in SVG file. That results in SVG file containing urls with `data:URI` scheme.  
 Although support for such url scheme is pretty good, some SVG parsers do not understand such urls. For example, Apache Batik fails to rasterize SVG markup including urls with `data:URI` to PDF.  
-If embedded icon is SVG itself, it can be included by copy/pasting its markup into target SVG file. 
+If embedded icon is SVG itself, it can be included by copy/pasting its markup into target SVG file.
  In order to point to inserted element, it should have an `id` attribute assigned, which can be assigned using [`id`](#id) loader parameter.
 
 ## Supported parameters
@@ -29,6 +29,9 @@ Defaults to `symbol`. Is used as the name of root tag in generated SVG markup.
 
 #### `id`
 If given, will be applied to the root tag (`symbol` by default, see description for [`tag`](#tag) option) in generated SVG markup.
+
+#### `class`
+If given, will be applied to the root tag in generated SVG markup.
 
 #### `viewBox`
 If given, overwrites value of `viewBox` attribute applied to the `svg` tag in source SVG file.
@@ -44,6 +47,8 @@ If given, overwrites value of `preserveAspectRatio` attribute applied to the `sv
 
 
 Parameters can be passed both in a url or from webpack config file. See [Using loaders](http://webpack.github.io/docs/using-loaders.html) section in webpack documentation for more details.
+
+The `id` and `class` parameters allow naming templates based on filename interpolation. See [`loader-utils#interpolatename`](https://github.com/webpack/loader-utils#interpolatename) for full usage details.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -12,17 +12,11 @@ module.exports = function(content) {
 	this.cacheable && this.cacheable();
 
 	var query = loaderUtils.getOptions(this);
-	var configKey = query.config || "svgAsSymbolLoader";
-	var options = this.options[configKey] || {};
 	var config = {
 		tag : 'symbol'
 	};
 	var context;
 	var content;
-
-	Object.keys(options).forEach(function (attr) {
-	    config[attr] = options[attr];
-	});
 
 	Object.keys(query).forEach(function (attr) {
 	    config[attr] = query[attr];
@@ -58,7 +52,7 @@ module.exports = function(content) {
 		        regExp: config.regExp
 		    }));
 		}
-	}.bind(this));
+	}, this);
 
 	// Move all child nodes from SVG element to the target element
 	var el = svgEl.firstChild;

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -43,23 +43,23 @@ describe('svg-as-symbol-loader', function() {
         var config = assign({}, globalConfig, {
             entry: './test/input/icon.js'
         });
-        
+
         webpack(config, function(err, stats) {
             expect(err).to.be(null);
             fs.readFile(getBundleFile(), function(err, data) {
                 expect(err).to.be(null);
                 var encoded = (0,eval)(data.toString());
-				
+
 				var outputDoc = new xmldom.DOMParser().parseFromString(encoded, 'text/xml');
 				var outputEl = outputDoc.documentElement;
                 expect(outputEl.tagName).to.be('symbol');
 
 				var rectNodes = xpath.select("//rect", outputDoc);
 				expect(rectNodes.length).to.be(1);
-				
+
 				var circleNodes = xpath.select("//circle", outputDoc);
 				expect(circleNodes.length).to.be(1);
-				
+
                 return done();
             });
         });
@@ -81,6 +81,28 @@ describe('svg-as-symbol-loader', function() {
 				var outputDoc = new xmldom.DOMParser().parseFromString(encoded, 'text/xml');
 				var outputEl = outputDoc.documentElement;
 				expect(outputEl.getAttribute('id')).to.be('foo');
+
+				return done();
+			});
+		});
+	});
+
+    it('should assign class attribute to generated symbol tag if it was provided by query', function(done) {
+		var config = assign({}, globalConfig, {
+			entry: './test/input/icon.js'
+		});
+
+		config.module.loaders[0].query.class = 'foo';
+
+		webpack(config, function(err) {
+			expect(err).to.be(null);
+			fs.readFile(getBundleFile(), function(err, data) {
+				expect(err).to.be(null);
+				var encoded = (0,eval)(data.toString());
+
+				var outputDoc = new xmldom.DOMParser().parseFromString(encoded, 'text/xml');
+				var outputEl = outputDoc.documentElement;
+				expect(outputEl.getAttribute('class')).to.be('foo');
 
 				return done();
 			});
@@ -173,6 +195,30 @@ describe('svg-as-symbol-loader', function() {
 				var path = xpath.select("//path", outputDoc);
 				expect(path.length).to.be(1);
 				expect(path[0].getAttribute('fill')).to.be('url(#' + prefixedId + ')');
+
+				return done();
+			});
+		});
+	});
+
+    it('should interpolate ID and class values', function(done) {
+        var config = assign({}, globalConfig, {
+			entry: './test/input/icon.js'
+		});
+
+		config.module.loaders[0].query.class = '[name].[ext]';
+		config.module.loaders[0].query.id = '[name]';
+
+		webpack(config, function(err) {
+			expect(err).to.be(null);
+			fs.readFile(getBundleFile(), function(err, data) {
+				expect(err).to.be(null);
+				var encoded = (0,eval)(data.toString());
+
+				var outputDoc = new xmldom.DOMParser().parseFromString(encoded, 'text/xml');
+				var outputEl = outputDoc.documentElement;
+				expect(outputEl.getAttribute('class')).to.be('icon.svg');
+				expect(outputEl.getAttribute('id')).to.be('icon');
 
 				return done();
 			});


### PR DESCRIPTION
This allows a class to be added to each SVG (useful if you're using a tag other than `symbol`).

It also adds the ability to use interpolated ID and class values using `loaderUtils.interpolateName`, which would close #5 

e.g.

```js
{
    test : /\.svg/,
    use : [
        {
            loader : 'svg-as-symbol-loader',
            options : {
                height : 20,
                width : 20,
                id : 'icon-[name]'
            }
        }
    ]
}
```

Tests added for class in config and value interpolation ✨ 